### PR TITLE
Declare build-tool dependency on cpphs

### DIFF
--- a/Gamgine.cabal
+++ b/Gamgine.cabal
@@ -1,6 +1,6 @@
 name: Gamgine
 version: 0.5.3
-cabal-version: >=1.6
+cabal-version: >=1.10
 build-type: Simple
 license: BSD3
 license-file: LICENSE
@@ -66,12 +66,13 @@ library
         unordered-containers >=0.2.4.0 && <0.3,
         data-lens >=2.10.4 && <2.12,
         pretty-show >=1.6.7 && <1.8,
-        cpphs >=1.18.4 && <1.21,
         filepath >=1.3.0.1 && <1.5,
         parsec >=3.1.5 && <3.2,
         zlib >=0.5.4.1 && <0.7,
         ListZipper >=1.2.0.2 && <1.3,
         composition >=1.0.1.0 && <1.1
+    build-tools: cpphs >=1.18.4 && <1.21
+    default-language: Haskell98
     cpp-options: -DCABAL
     cc-options: -Wno-unused-result
     c-sources:


### PR DESCRIPTION
This fixes build failures cabal as `build-tools` is the proper way to
declare a dependency on a build-tool such as `cpphs` as otherwise
cabal won't know it needs to build `cpphs` and place it into your $PATH

For more information see also 
https://www.haskell.org/cabal/users-guide/developing-packages.html#pkg-field-build-tools

This also updates the cabal spec to use version 1.10 of the spec and
explicitly asks to put the compiler into Haskell98 mode (instead of
using GHC's not well defined default language mode which is neither H98nor H2010)
for better future-proofing.